### PR TITLE
Use PATH if possible

### DIFF
--- a/Example/Program.fs
+++ b/Example/Program.fs
@@ -8,12 +8,12 @@ module Program =
     let main argv =
         let info = DotnetEnvironmentInfo.Get ()
         Console.WriteLine info
-        Console.WriteLine ("SDKs:")
+        Console.WriteLine "SDKs:"
 
         for sdk in info.Sdks do
             Console.WriteLine $"SDK: %O{sdk}"
 
-        Console.WriteLine ("Frameworks:")
+        Console.WriteLine "Frameworks:"
 
         for f in info.Frameworks do
             Console.WriteLine $"Framework: %O{f}"


### PR DESCRIPTION
Fixes #4, for a certain value of "fixes". If your symlinky `dotnet` is at the top of your path, we'll find it and use it, so we get all the available results.