### PR TITLE
Fix code example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ See [the example](Example/Program.fs).
 ```fsharp
 let info = DotnetEnvironmentInfo.Get ()
 // or, if you already know a path to the `dotnet` executable...
-let info = DotnetEnvironmentInfo.Get "/path/to/dotnet"
+let info = DotnetEnvironmentInfo.GetSpecific "/path/to/dotnet"
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
This has the side-effect of creating a new NuGet package version, which is good because the attestation in #6 is currently attesting an artefact that we didn't publish! (`dotnet pack` is nondeterministic, in this the year of our lord 2024, https://github.com/NuGet/Home/issues/8601)