### PR TITLE
Wait for NuGet readiness and assert package contents

### DIFF
--- a/.github/workflows/assert-contents.sh
+++ b/.github/workflows/assert-contents.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+mkdir from-nuget && cp from-nuget.nupkg from-nuget/zip.zip && cd from-nuget && unzip zip.zip && cd - || exit 1
+
+mkdir from-local && cp packed/*.nupkg from-local/zip.zip && cd from-local && unzip zip.zip && cd - || exit 1
+
+find from-local -type f -exec sha256sum {} \; | sort > from-local.txt
+find from-nuget -type f -and -not -name '.signature.p7s' -exec sha256sum {} \; | sort > from-nuget.txt
+
+diff from-local.txt from-nuget.txt

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -240,6 +240,7 @@ jobs:
         if: steps.publish-success.outputs.result == 'published'
         run: 'bash ./.github/workflows/assert-contents.sh'
       - name: Attest Build Provenance
+        if: steps.publish-success.outputs.result == 'published'
         uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
         with:
           subject-path: "from-nuget.nupkg"

--- a/.github/workflows/dotnet.yaml
+++ b/.github/workflows/dotnet.yaml
@@ -208,6 +208,10 @@ jobs:
     if: ${{ !github.event.repository.fork && github.ref == 'refs/heads/main' }}
     needs: [attestation]
     environment: main-deploy
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Install Nix
@@ -221,7 +225,24 @@ jobs:
           name: nuget-package
           path: packed
       - name: Publish to NuGet
-        run: nix develop --command dotnet nuget push "packed/WoofWare.DotnetRuntimeLocator.*.nupkg" --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json --skip-duplicate
+        id: publish-success
+        env:
+          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+        run: 'nix develop --command ./.github/workflows/nuget-push.sh "packed/WoofWare.DotnetRuntimeLocator.*.nupkg"'
+      - name: Wait for availability
+        if: steps.publish-success.outputs.result == 'published'
+        env:
+          PACKAGE_VERSION: ${{ steps.publish-success.outputs.version }}
+        run: 'echo "$PACKAGE_VERSION" && while ! curl --fail -o from-nuget.nupkg "https://www.nuget.org/api/v2/package/WoofWare.DotnetRuntimeLocator/$PACKAGE_VERSION" ; do sleep 10; done'
+      # Astonishingly, NuGet.org considers it to be "more secure" to tamper with my package after upload (https://devblogs.microsoft.com/nuget/introducing-repository-signatures/).
+      # So we have to *re-attest* it after it's uploaded. Mind-blowing.
+      - name: Assert package contents
+        if: steps.publish-success.outputs.result == 'published'
+        run: 'bash ./.github/workflows/assert-contents.sh'
+      - name: Attest Build Provenance
+        uses: actions/attest-build-provenance@897ed5eab6ed058a474202017ada7f40bfa52940 # v1.0.0
+        with:
+          subject-path: "from-nuget.nupkg"
 
   github-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/nuget-push.sh
+++ b/.github/workflows/nuget-push.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+SOURCE_NUPKG=$(find . type f -name '*.nupkg')
+
+PACKAGE_VERSION=$(basename "$SOURCE_NUPKG" | rev | cut -d '.' -f 2-4 | rev)
+
+echo "version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+
+tmp=$(mktemp)
+
+if ! dotnet nuget push "$SOURCE_NUPKG" --api-key "$NUGET_API_KEY" --source https://api.nuget.org/v3/index.json --skip-duplicate > "$tmp" ; then
+    cat "$tmp"
+    if grep 'already exists at feed' "$tmp" ; then
+        echo "result=skipped" >> "$GITHUB_OUTPUT"
+        exit 0
+    else
+        echo "Unexpected failure to upload"
+        exit 1
+    fi
+fi
+
+echo "result=published" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This should hopefully successfully not fire after merge to main, because there's no change to the package.