### PR TITLE
Reject a JSON null in a member declared non-nullable

### DIFF
--- a/WoofWare.DotnetRuntimeLocator/DotnetRuntime.cs
+++ b/WoofWare.DotnetRuntimeLocator/DotnetRuntime.cs
@@ -264,7 +264,14 @@ public static class DotnetRuntime
     /// Parse a runtimeconfig.json file.
     /// </summary>
     /// <param name="contents">Contents of the runtimeconfig.json file to parse.</param>
-    /// <exception cref="NullReferenceException">I think this can't happen, but the docs suggest that deserialization might return null.</exception>
+    /// <returns>
+    /// The parsed file, or null if <paramref name="contents"/> was the JSON document "null".
+    /// </returns>
+    /// <exception cref="JsonException">
+    /// <paramref name="contents"/> is not JSON, or is missing a member the format requires, or spells such a
+    /// member as null. The message names the offending member in the last case; see
+    /// <see cref="RuntimeConfig.RuntimeOptions"/> for why a null there is refused rather than represented.
+    /// </exception>
     public static RuntimeConfig? DeserializeRuntimeConfig(string contents)
     {
         return JsonSerializer.Deserialize<RuntimeConfig>(contents, _options);

--- a/WoofWare.DotnetRuntimeLocator/RuntimeConfigOptions.cs
+++ b/WoofWare.DotnetRuntimeLocator/RuntimeConfigOptions.cs
@@ -20,10 +20,10 @@ namespace WoofWare.DotnetRuntimeLocator;
 ///         it. Checking on the way in instead makes the type's non-nullability a fact rather than a wish.
 ///     </para>
 ///     <para>
-///         Refusing is also what the format itself does for three of the four members. Measured against
-///         the real host on Microsoft.NETCore.App 9.0.0: a null "tfm", "name" or "version" makes it exit
-///         with 0x8000808b (ResolverInitFailure) and print nothing whatsoever, so nulling one of those
-///         does not produce a runnable app under any reading. The fourth, "runtimeOptions", is the one
+///         Refusing is also what the format itself does for three of the four members: on the real host
+///         (Microsoft.NETCore.App 9.0.0), a null "tfm", "name" or "version" makes it exit with
+///         0x8000808b (ResolverInitFailure) and print nothing whatsoever, so nulling one of those does
+///         not produce a runnable app under any reading. The fourth, "runtimeOptions", is the one
 ///         divergence, and is discussed on <see cref="RuntimeConfig.RuntimeOptions" />.
 ///     </para>
 ///     <para>
@@ -38,9 +38,9 @@ namespace WoofWare.DotnetRuntimeLocator;
 ///         these records get built, and because it is what the same file already gets for its other
 ///         defects: <c>System.Text.Json</c> raises <see cref="JsonException" /> both for malformed JSON
 ///         and for an absent <c>required</c> member, so a caller who is parsing a file it does not
-///         control still needs exactly one catch. It was measured that
-///         <see cref="JsonSerializer" /> propagates whatever an <c>init</c> accessor throws, unwrapped,
-///         so choosing anything else here would leak a second exception type out of a parse call.
+///         control still needs exactly one catch. <see cref="JsonSerializer" /> propagates whatever an
+///         <c>init</c> accessor throws, unwrapped, so choosing anything else here would leak a second
+///         exception type out of a parse call.
 ///     </para>
 /// </remarks>
 internal static class NonNullableMember
@@ -83,10 +83,9 @@ internal static class NonNullableMember
     ///         cast away from being writable again.
     ///     </para>
     ///     <para>
-    ///         One consequence worth knowing: two records built from the same source list now hold
-    ///         different list instances, and this record's compiler-generated equality compares lists by
-    ///         reference, so they compare unequal. That was already true of two separately-parsed
-    ///         configs; it is now also true of two built in code from one list.
+    ///         One consequence worth knowing: two records built from the same source list hold different
+    ///         list instances, and this record's compiler-generated equality compares lists by reference,
+    ///         so they compare unequal. The same goes for two separately-parsed configs.
     ///     </para>
     /// </remarks>
     /// <exception cref="JsonException">Some element of <paramref name="value" /> is null.</exception>
@@ -580,10 +579,10 @@ public record RuntimeConfig
     /// </summary>
     /// <remarks>
     ///     This is the one place where refusing a null is a policy of ours rather than the format's. The
-    ///     real host was measured on Microsoft.NETCore.App 9.0.0: it rejects a file with no
-    ///     "runtimeOptions" member ("Invalid runtimeconfig.json"), but treats <c>"runtimeOptions":null</c>
-    ///     as an empty options object, which is fatal for a framework-dependent app ("did not specify a
-    ///     framework") and harmless for a self-contained one. Since an empty options object is not
+    ///     real host (Microsoft.NETCore.App 9.0.0) rejects a file with no "runtimeOptions" member
+    ///     ("Invalid runtimeconfig.json"), but treats <c>"runtimeOptions":null</c> as an empty options
+    ///     object, which is fatal for a framework-dependent app ("did not specify a framework") and
+    ///     harmless for a self-contained one. Since an empty options object is not
     ///     representable here either — <see cref="RuntimeOptions.Tfm" /> is itself non-nullable — the two
     ///     spellings of "this file says nothing" are treated alike rather than one of them being handed
     ///     back as a null.

--- a/WoofWare.DotnetRuntimeLocator/RuntimeConfigOptions.cs
+++ b/WoofWare.DotnetRuntimeLocator/RuntimeConfigOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Text;
 using System.Text.Json;
@@ -8,21 +9,129 @@ using System.Text.Json.Serialization;
 namespace WoofWare.DotnetRuntimeLocator;
 
 /// <summary>
+///     Enforcement for the members of this file's types whose slots are non-nullable.
+/// </summary>
+/// <remarks>
+///     <para>
+///         C#'s <c>required</c> constrains the JSON member to be <em>present</em>; it says nothing about
+///         its value. So <c>{"runtimeOptions":null}</c> satisfies <c>required</c> and lands a null in a
+///         slot the type declares can never hold one, and the first consumer to dereference it gets a
+///         <see cref="NullReferenceException" /> naming their own code rather than the file which caused
+///         it. Checking on the way in instead makes the type's non-nullability a fact rather than a wish.
+///     </para>
+///     <para>
+///         Refusing is also what the format itself does for three of the four members. Measured against
+///         the real host on Microsoft.NETCore.App 9.0.0: a null "tfm", "name" or "version" makes it exit
+///         with 0x8000808b (ResolverInitFailure) and print nothing whatsoever, so nulling one of those
+///         does not produce a runnable app under any reading. The fourth, "runtimeOptions", is the one
+///         divergence, and is discussed on <see cref="RuntimeConfig.RuntimeOptions" />.
+///     </para>
+///     <para>
+///         This lives in the <c>init</c> accessors rather than in a converter or in
+///         <see cref="DotnetRuntime.DeserializeRuntimeConfig" />, because the invariant belongs to the
+///         type: these records are public, so a consumer can deserialize them itself — the test suite
+///         does — or build one in code, and both paths must uphold it. An accessor also covers an
+///         element nested in "frameworks" or "includedFrameworks" without any extra machinery.
+///     </para>
+///     <para>
+///         The exception is a <see cref="JsonException" /> because deserializing is overwhelmingly how
+///         these records get built, and because it is what the same file already gets for its other
+///         defects: <c>System.Text.Json</c> raises <see cref="JsonException" /> both for malformed JSON
+///         and for an absent <c>required</c> member, so a caller who is parsing a file it does not
+///         control still needs exactly one catch. It was measured that
+///         <see cref="JsonSerializer" /> propagates whatever an <c>init</c> accessor throws, unwrapped,
+///         so choosing anything else here would leak a second exception type out of a parse call.
+///     </para>
+/// </remarks>
+internal static class NonNullableMember
+{
+    /// <summary>
+    ///     Return <paramref name="value" />, or refuse it if it is null.
+    /// </summary>
+    /// <param name="value">The value the member is being set to.</param>
+    /// <param name="jsonName">The member's name as it is spelled in the file, for the error message.</param>
+    /// <exception cref="JsonException"><paramref name="value" /> is null.</exception>
+    internal static T OrThrow<T>(T? value, string jsonName) where T : class
+    {
+        return value ?? throw new JsonException(
+            $"The runtimeconfig.json member \"{jsonName}\" was present but null. This library declares that member non-nullable, so it refuses the file rather than hand you a null in a slot which cannot hold one. Give the member a value, or omit it if it is one of the optional ones.");
+    }
+
+    /// <summary>
+    ///     Return an unaliased, unmodifiable copy of <paramref name="value" />, or refuse it if any
+    ///     element is null.
+    /// </summary>
+    /// <param name="value">
+    ///     The list the member is being set to. A null list is fine and passes straight through: the
+    ///     members holding lists are themselves optional, and it is only their <em>elements</em> which
+    ///     are declared non-nullable.
+    /// </param>
+    /// <param name="jsonName">The member's name as it is spelled in the file, for the error message.</param>
+    /// <remarks>
+    ///     <para>
+    ///         This case needs checking on the list rather than in an accessor of the element type,
+    ///         because an element spelled <c>null</c> constructs no element at all — there is nothing
+    ///         whose accessor could run.
+    ///     </para>
+    ///     <para>
+    ///         It copies rather than validating in place, because a check on a list someone else holds
+    ///         only establishes the invariant for an instant: the caller could null an entry afterwards,
+    ///         and what the deserializer builds is a <see cref="List{T}" />, which anyone holding the
+    ///         <see cref="IReadOnlyList{T}" /> can downcast and write to. Both would falsify a claim
+    ///         these records make about themselves. The copy is wrapped rather than handed back as an
+    ///         array for the same reason: an array exposed as <see cref="IReadOnlyList{T}" /> is one
+    ///         cast away from being writable again.
+    ///     </para>
+    ///     <para>
+    ///         One consequence worth knowing: two records built from the same source list now hold
+    ///         different list instances, and this record's compiler-generated equality compares lists by
+    ///         reference, so they compare unequal. That was already true of two separately-parsed
+    ///         configs; it is now also true of two built in code from one list.
+    ///     </para>
+    /// </remarks>
+    /// <exception cref="JsonException">Some element of <paramref name="value" /> is null.</exception>
+    internal static IReadOnlyList<T>? ElementsOrThrow<T>(IReadOnlyList<T?>? value, string jsonName) where T : class
+    {
+        if (value == null) return null;
+
+        var copy = new T[value.Count];
+
+        for (var i = 0; i < value.Count; i++)
+            copy[i] = value[i] ?? throw new JsonException(
+                $"Entry {i} of the runtimeconfig.json member \"{jsonName}\" was null. This library declares the entries of that list non-nullable, so it refuses the file rather than hand you a null in a slot which cannot hold one. Give the entry a value, or remove it.");
+
+        return new ReadOnlyCollection<T>(copy);
+    }
+}
+
+/// <summary>
 ///     The type of a "framework" entry in the "runtimeOptions" setting of a runtimeconfig.json file.
 /// </summary>
 public record RuntimeConfigFramework
 {
-    /// <summary>
-    ///     For example, "Microsoft.NETCore.App".
-    /// </summary>
-    [JsonPropertyName("name")]
-    public required string Name { get; init; }
+    private readonly string _name = null!;
+    private readonly string _version = null!;
 
     /// <summary>
-    ///     For example, "9.0.0".
+    ///     For example, "Microsoft.NETCore.App". Never null: a file spelling it <c>null</c> is rejected
+    ///     when it is parsed.
+    /// </summary>
+    [JsonPropertyName("name")]
+    public required string Name
+    {
+        get => _name;
+        init => _name = NonNullableMember.OrThrow(value, "name");
+    }
+
+    /// <summary>
+    ///     For example, "9.0.0". Never null: a file spelling it <c>null</c> is rejected when it is parsed.
     /// </summary>
     [JsonPropertyName("version")]
-    public required string Version { get; init; }
+    public required string Version
+    {
+        get => _version;
+        init => _version = NonNullableMember.OrThrow(value, "version");
+    }
 }
 
 /// <summary>
@@ -371,9 +480,18 @@ public static class ConfigProperties
 /// </summary>
 public record RuntimeOptions
 {
-    /// Target framework moniker, such as "net9.0".
+    private readonly string _tfm = null!;
+
+    /// <summary>
+    ///     Target framework moniker, such as "net9.0". Never null: a file spelling it <c>null</c> is
+    ///     rejected when it is parsed.
+    /// </summary>
     [JsonPropertyName("tfm")]
-    public required string Tfm { get; init; }
+    public required string Tfm
+    {
+        get => _tfm;
+        init => _tfm = NonNullableMember.OrThrow(value, "tfm");
+    }
 
     /// <summary>
     ///     The .NET runtime which this executable expects.
@@ -383,18 +501,36 @@ public record RuntimeOptions
     [JsonPropertyName("framework")]
     public RuntimeConfigFramework? Framework { get; init; }
 
+    private readonly IReadOnlyList<RuntimeConfigFramework>? _frameworks;
+    private readonly IReadOnlyList<RuntimeConfigFramework>? _includedFrameworks;
+
     /// <summary>
     ///     Any of these runtimes by itself would be enough to run this executable.
     ///     It's much more normal to see a single `framework` instead of this.
+    ///     The list may be absent, but none of its entries is ever null: a file spelling an entry
+    ///     <c>null</c> is rejected when it is parsed, and what is stored is an unmodifiable copy, so
+    ///     nothing can put a null there afterwards either.
     /// </summary>
     [JsonPropertyName("frameworks")]
-    public IReadOnlyList<RuntimeConfigFramework>? Frameworks { get; init; }
+    public IReadOnlyList<RuntimeConfigFramework>? Frameworks
+    {
+        get => _frameworks;
+        init => _frameworks = NonNullableMember.ElementsOrThrow<RuntimeConfigFramework>(value, "frameworks");
+    }
 
     /// <summary>
     ///     This is a self-contained executable which has these framework entirely contained next to it.
+    ///     The list may be absent, but none of its entries is ever null: a file spelling an entry
+    ///     <c>null</c> is rejected when it is parsed, and what is stored is an unmodifiable copy, so
+    ///     nothing can put a null there afterwards either.
     /// </summary>
     [JsonPropertyName("includedFrameworks")]
-    public IReadOnlyList<RuntimeConfigFramework>? IncludedFrameworks { get; init; }
+    public IReadOnlyList<RuntimeConfigFramework>? IncludedFrameworks
+    {
+        get => _includedFrameworks;
+        init => _includedFrameworks =
+            NonNullableMember.ElementsOrThrow<RuntimeConfigFramework>(value, "includedFrameworks");
+    }
 
     /// <summary>
     ///     This application advertises that it's fine with running under this roll-forward.
@@ -436,11 +572,28 @@ public record RuntimeOptions
 /// </summary>
 public record RuntimeConfig
 {
+    private readonly RuntimeOptions _runtimeOptions = null!;
+
     /// <summary>
-    ///     The contents of the file.
+    ///     The contents of the file. Never null: a file spelling it <c>null</c> is rejected when it is
+    ///     parsed, exactly as a file omitting it is.
     /// </summary>
+    /// <remarks>
+    ///     This is the one place where refusing a null is a policy of ours rather than the format's. The
+    ///     real host was measured on Microsoft.NETCore.App 9.0.0: it rejects a file with no
+    ///     "runtimeOptions" member ("Invalid runtimeconfig.json"), but treats <c>"runtimeOptions":null</c>
+    ///     as an empty options object, which is fatal for a framework-dependent app ("did not specify a
+    ///     framework") and harmless for a self-contained one. Since an empty options object is not
+    ///     representable here either — <see cref="RuntimeOptions.Tfm" /> is itself non-nullable — the two
+    ///     spellings of "this file says nothing" are treated alike rather than one of them being handed
+    ///     back as a null.
+    /// </remarks>
     [JsonPropertyName("runtimeOptions")]
-    public required RuntimeOptions RuntimeOptions { get; init; }
+    public required RuntimeOptions RuntimeOptions
+    {
+        get => _runtimeOptions;
+        init => _runtimeOptions = NonNullableMember.OrThrow(value, "runtimeOptions");
+    }
 }
 
 [JsonSourceGenerationOptions(WriteIndented = true)]

--- a/WoofWare.DotnetRuntimeLocator/Test/TestRuntimeConfigParse.fs
+++ b/WoofWare.DotnetRuntimeLocator/Test/TestRuntimeConfigParse.fs
@@ -124,8 +124,8 @@ module TestRuntimeConfigParse =
     /// top-level one. Every expectation here was measured against the real host on
     /// Microsoft.NETCore.App 10.0.7: it escapes only `"`, `\` and the C0 controls, so HTML-sensitive
     /// characters, DEL, Latin-1, U+2028, U+2029 and astral-plane characters all survive as
-    /// themselves. This is precisely what the first version of this code got wrong by rendering
-    /// through `Utf8JsonWriter`, whose default encoder escapes most of them.
+    /// themselves. Note that `Utf8JsonWriter`'s default encoder escapes most of them, so it cannot be
+    /// used to render these.
     [<Test>]
     let ``Nested strings are escaped exactly as the host escapes them`` () =
         let content =
@@ -329,9 +329,8 @@ module TestRuntimeConfigParse =
     // ------------------------------------------------------------------
 
     /// C#'s `required` checks that the JSON *member is present*, not that its value is non-null, so
-    /// before this was fixed each of these deserialized happily and handed the caller a null in a slot
-    /// the type says can never be null. The first one a consumer touched then threw
-    /// `NullReferenceException` from somewhere unrelated to the file which caused it.
+    /// without an explicit check each of these deserializes happily and hands the caller a null in a
+    /// slot the type says can never be null.
     [<TestCase("""{"runtimeOptions":null}""", "runtimeOptions")>]
     [<TestCase("""{"runtimeOptions":{"tfm":null}}""", "tfm")>]
     [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","framework":{"name":null,"version":"8.0.0"}}}""", "name")>]
@@ -353,9 +352,8 @@ module TestRuntimeConfigParse =
         exn.Message |> shouldContainText jsonMember
 
     /// The types are public and carry their own `JsonPropertyName`s, so a consumer may reasonably
-    /// deserialize them without going through `DeserializeRuntimeConfig` — the first test in this
-    /// fixture does exactly that. The invariant has to hold on that path too, which rules out
-    /// validating in `DeserializeRuntimeConfig` itself.
+    /// deserialize them without going through `DeserializeRuntimeConfig`. The invariant has to hold on
+    /// that path too, which rules out validating in `DeserializeRuntimeConfig` itself.
     [<Test>]
     let ``The rejection does not depend on going through DeserializeRuntimeConfig`` () =
         let exn =
@@ -368,8 +366,8 @@ module TestRuntimeConfigParse =
 
     /// Constructing one directly is checked too: the invariant belongs to the type, not to the
     /// deserializer, and a `RuntimeConfig` built in code is just as likely to be handed to a consumer.
-    /// It is a `JsonException` even here, because `JsonSerializer` was measured to propagate whatever an
-    /// `init` accessor throws unwrapped, so an accessor which threw anything else would leak a second
+    /// It is a `JsonException` even here, because `JsonSerializer` propagates whatever an `init`
+    /// accessor throws unwrapped, so an accessor which threw anything else would leak a second
     /// exception type out of a parse call — which is the more common path by far.
     [<Test>]
     let ``Constructing with a null is rejected as well`` () =
@@ -379,9 +377,9 @@ module TestRuntimeConfigParse =
         exn.Message |> shouldContainText "runtimeOptions"
 
     /// The counterpart control: the members which really are optional must keep deserializing from an
-    /// explicit null, rather than being swept up by the rejection above. Measured against the real
-    /// host on Microsoft.NETCore.App 9.0.0: a runtimeconfig.json with `"configProperties": null` runs
-    /// the app to completion, so refusing this file would be inventing a rule the format does not have.
+    /// explicit null, rather than being swept up by the rejection above. On the real host
+    /// (Microsoft.NETCore.App 9.0.0), a runtimeconfig.json with `"configProperties": null` runs the app
+    /// to completion, so refusing this file would be inventing a rule the format does not have.
     [<Test>]
     let ``A null in a genuinely optional member still parses`` () =
         let content =
@@ -415,8 +413,8 @@ module TestRuntimeConfigParse =
         options.Frameworks.[0]
         |> shouldEqual (RuntimeConfigFramework (Name = "Microsoft.NETCore.App", Version = "8.0.0"))
 
-    /// ... and the same for the other direction: what we hand out cannot be downcast to something
-    /// mutable, which `List<_>` — what the deserializer builds — otherwise can be.
+    /// The other direction: what we hand out cannot be downcast to something mutable, which `List<_>` —
+    /// what the deserializer builds — otherwise can be.
     [<Test>]
     let ``The exposed list cannot be mutated through a downcast`` () =
         let content =
@@ -447,10 +445,10 @@ module TestRuntimeConfigParse =
     /// form, DEL, Latin-1, the HTML-sensitive characters a JavaScript encoder would escape but the host
     /// does not, the JavaScript line terminators, and an astral-plane character.
     ///
-    /// An earlier version of this generator was restricted to `[A-Za-z0-9 ._-]`, on the reasoning that
-    /// the oracle should not have to reimplement an escaping policy to agree with it. That did not
-    /// decouple the test from the policy; it deleted the only inputs which could detect getting the
-    /// policy wrong, and it duly hid a real bug. Fragments are whole strings rather than chars so that
+    /// Restricting this generator to something like `[A-Za-z0-9 ._-]`, on the reasoning that the oracle
+    /// should not have to reimplement an escaping policy to agree with it, does not decouple the test
+    /// from the policy: it deletes the only inputs which could detect getting the policy wrong.
+    /// Fragments are whole strings rather than chars so that
     /// the astral one contributes a complete surrogate pair: a lone surrogate cannot appear in JSON,
     /// and the serialiser would substitute U+FFFD for it.
     let private genSafeString : Gen<string> =

--- a/WoofWare.DotnetRuntimeLocator/Test/TestRuntimeConfigParse.fs
+++ b/WoofWare.DotnetRuntimeLocator/Test/TestRuntimeConfigParse.fs
@@ -1,6 +1,7 @@
 namespace WoofWare.DotnetRuntimeLocator.Test
 
 open System
+open System.Collections.Generic
 open System.IO
 open System.Reflection
 open System.Text.Json
@@ -324,6 +325,110 @@ module TestRuntimeConfigParse =
         exn.Message |> shouldContainText "undefined JsonElement"
 
     // ------------------------------------------------------------------
+    // A JSON null in a slot the type declares non-nullable.
+    // ------------------------------------------------------------------
+
+    /// C#'s `required` checks that the JSON *member is present*, not that its value is non-null, so
+    /// before this was fixed each of these deserialized happily and handed the caller a null in a slot
+    /// the type says can never be null. The first one a consumer touched then threw
+    /// `NullReferenceException` from somewhere unrelated to the file which caused it.
+    [<TestCase("""{"runtimeOptions":null}""", "runtimeOptions")>]
+    [<TestCase("""{"runtimeOptions":{"tfm":null}}""", "tfm")>]
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","framework":{"name":null,"version":"8.0.0"}}}""", "name")>]
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","framework":{"name":"Microsoft.NETCore.App","version":null}}}""",
+               "version")>]
+    // The array-valued members too: a null in an element is exactly as fatal as one at the top level.
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","frameworks":[{"name":null,"version":"8.0.0"}]}}""", "name")>]
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","includedFrameworks":[{"name":"A","version":null}]}}""", "version")>]
+    // A whole element spelled null, rather than a member inside one. The lists are optional, but their
+    // *elements* are not, and nothing constructs a `RuntimeConfigFramework` here for an accessor to
+    // catch — so this needs checking on the list itself.
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","frameworks":[null]}}""", "frameworks")>]
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","frameworks":[{"name":"A","version":"1.0"},null]}}""", "frameworks")>]
+    [<TestCase("""{"runtimeOptions":{"tfm":"net8.0","includedFrameworks":[null]}}""", "includedFrameworks")>]
+    let ``A null in a non-nullable member is rejected, naming the member`` (content : string) (jsonMember : string) =
+        let exn =
+            Assert.Throws<JsonException> (fun () -> DotnetRuntime.DeserializeRuntimeConfig content |> ignore)
+
+        exn.Message |> shouldContainText jsonMember
+
+    /// The types are public and carry their own `JsonPropertyName`s, so a consumer may reasonably
+    /// deserialize them without going through `DeserializeRuntimeConfig` — the first test in this
+    /// fixture does exactly that. The invariant has to hold on that path too, which rules out
+    /// validating in `DeserializeRuntimeConfig` itself.
+    [<Test>]
+    let ``The rejection does not depend on going through DeserializeRuntimeConfig`` () =
+        let exn =
+            Assert.Throws<JsonException> (fun () ->
+                JsonSerializer.Deserialize<RuntimeConfig> """{"runtimeOptions":null}"""
+                |> ignore
+            )
+
+        exn.Message |> shouldContainText "runtimeOptions"
+
+    /// Constructing one directly is checked too: the invariant belongs to the type, not to the
+    /// deserializer, and a `RuntimeConfig` built in code is just as likely to be handed to a consumer.
+    /// It is a `JsonException` even here, because `JsonSerializer` was measured to propagate whatever an
+    /// `init` accessor throws unwrapped, so an accessor which threw anything else would leak a second
+    /// exception type out of a parse call — which is the more common path by far.
+    [<Test>]
+    let ``Constructing with a null is rejected as well`` () =
+        let exn =
+            Assert.Throws<JsonException> (fun () -> RuntimeConfig (RuntimeOptions = null) |> ignore)
+
+        exn.Message |> shouldContainText "runtimeOptions"
+
+    /// The counterpart control: the members which really are optional must keep deserializing from an
+    /// explicit null, rather than being swept up by the rejection above. Measured against the real
+    /// host on Microsoft.NETCore.App 9.0.0: a runtimeconfig.json with `"configProperties": null` runs
+    /// the app to completion, so refusing this file would be inventing a rule the format does not have.
+    [<Test>]
+    let ``A null in a genuinely optional member still parses`` () =
+        let content =
+            """{"runtimeOptions":{"tfm":"net8.0","framework":null,"frameworks":null,"includedFrameworks":null,"rollForward":null,"configProperties":null}}"""
+
+        let actual = DotnetRuntime.DeserializeRuntimeConfig content
+
+        actual.RuntimeOptions.Tfm |> shouldEqual "net8.0"
+        actual.RuntimeOptions.Framework |> shouldEqual null
+        actual.RuntimeOptions.Frameworks |> shouldEqual null
+        actual.RuntimeOptions.IncludedFrameworks |> shouldEqual null
+        actual.RuntimeOptions.RollForward |> shouldEqual (Nullable ())
+        actual.RuntimeOptions.ConfigProperties |> shouldEqual null
+        hostProperties actual.RuntimeOptions |> shouldEqual []
+
+    /// Checking the entries once is not enough on its own: if the caller's own list were kept, they
+    /// could null an entry afterwards and the "no null entries" claim would stop being true of an
+    /// object which had already been validated. So the entries are snapshotted as they are checked.
+    [<Test>]
+    let ``A list handed in at construction is snapshotted, not aliased`` () =
+        let source =
+            [| RuntimeConfigFramework (Name = "Microsoft.NETCore.App", Version = "8.0.0") |]
+
+        let options =
+            RuntimeOptions (Tfm = "net8.0", Frameworks = (source :> IReadOnlyList<RuntimeConfigFramework>))
+
+        source.[0] <- null
+
+        options.Frameworks.Count |> shouldEqual 1
+
+        options.Frameworks.[0]
+        |> shouldEqual (RuntimeConfigFramework (Name = "Microsoft.NETCore.App", Version = "8.0.0"))
+
+    /// ... and the same for the other direction: what we hand out cannot be downcast to something
+    /// mutable, which `List<_>` — what the deserializer builds — otherwise can be.
+    [<Test>]
+    let ``The exposed list cannot be mutated through a downcast`` () =
+        let content =
+            """{"runtimeOptions":{"tfm":"net8.0","frameworks":[{"name":"Microsoft.NETCore.App","version":"8.0.0"}]}}"""
+
+        let actual = DotnetRuntime.DeserializeRuntimeConfig content
+        let asMutable = actual.RuntimeOptions.Frameworks :?> IList<RuntimeConfigFramework>
+
+        asMutable.IsReadOnly |> shouldEqual true
+        Assert.Throws<NotSupportedException> (fun () -> asMutable.[0] <- null) |> ignore
+
+    // ------------------------------------------------------------------
     // Property test: the projection against an independent renderer.
     // ------------------------------------------------------------------
 
@@ -519,3 +624,207 @@ module TestRuntimeConfigParse =
             actual = expected
 
         Check.One (Config.QuickThrowOnFailure.WithMaxTest 500, Prop.forAll (Arb.fromGen genConfigProperties) property)
+
+    // ------------------------------------------------------------------
+    // Property test: a null in any non-nullable member, wherever it sits.
+    // ------------------------------------------------------------------
+
+    type private FrameworkModel =
+        {
+            Name : string
+            Version : string
+        }
+
+    type private ConfigModel =
+        {
+            Tfm : string
+            Framework : FrameworkModel option
+            Frameworks : FrameworkModel list
+            IncludedFrameworks : FrameworkModel list
+        }
+
+    /// A place in the document holding a value whose slot in the parsed type is non-nullable. The
+    /// cases are enumerated from the *model* rather than from the implementation, which is what makes
+    /// this an oracle: a member the implementation forgets to check still appears here, and the
+    /// property then fails at it.
+    type private Position =
+        | AtRuntimeOptions
+        | AtTfm
+        | AtFrameworkName
+        | AtFrameworkVersion
+        | AtFrameworksName of int
+        | AtFrameworksVersion of int
+        | AtIncludedName of int
+        | AtIncludedVersion of int
+        /// A whole element of one of the lists, rather than a member inside one. The lists themselves
+        /// are optional, but their elements are not.
+        | AtFrameworksElement of int
+        | AtIncludedElement of int
+
+    /// The JSON member name at this position: what the rejection is required to name, so that the
+    /// file's author can find the offending line.
+    let private memberName (position : Position) : string =
+        match position with
+        | Position.AtRuntimeOptions -> "runtimeOptions"
+        | Position.AtTfm -> "tfm"
+        | Position.AtFrameworkName
+        | Position.AtFrameworksName _
+        | Position.AtIncludedName _ -> "name"
+        | Position.AtFrameworkVersion
+        | Position.AtFrameworksVersion _
+        | Position.AtIncludedVersion _ -> "version"
+        // A null element has no member name of its own, so the containing list is what gets named.
+        | Position.AtFrameworksElement _ -> "frameworks"
+        | Position.AtIncludedElement _ -> "includedFrameworks"
+
+    /// Every position this particular document actually has: an array index only exists if the array
+    /// is that long, and the single `framework` only if the model has one.
+    let private positions (model : ConfigModel) : Position list =
+        [
+            Position.AtRuntimeOptions
+            Position.AtTfm
+
+            match model.Framework with
+            | Some _ ->
+                Position.AtFrameworkName
+                Position.AtFrameworkVersion
+            | None -> ()
+
+            for i in 0 .. model.Frameworks.Length - 1 do
+                Position.AtFrameworksName i
+                Position.AtFrameworksVersion i
+                Position.AtFrameworksElement i
+
+            for i in 0 .. model.IncludedFrameworks.Length - 1 do
+                Position.AtIncludedName i
+                Position.AtIncludedVersion i
+                Position.AtIncludedElement i
+        ]
+
+    /// Render the model as a runtimeconfig.json, replacing the value at `nulled` — if there is one —
+    /// with JSON null. Strings are quoted by `System.Text.Json` so that the input does not depend on
+    /// any escaping decision of ours.
+    let private renderConfig (model : ConfigModel) (nulled : Position option) : string =
+        let value (position : Position) (v : string) : string =
+            if nulled = Some position then
+                "null"
+            else
+                JsonSerializer.Serialize v
+
+        let renderFramework (namePosition : Position) (versionPosition : Position) (f : FrameworkModel) : string =
+            $"""{{"name":%s{value namePosition f.Name},"version":%s{value versionPosition f.Version}}}"""
+
+        let renderList
+            (name : string)
+            (at : int -> Position * Position * Position)
+            (frameworks : FrameworkModel list)
+            : string
+            =
+            frameworks
+            |> List.mapi (fun i f ->
+                let namePosition, versionPosition, elementPosition = at i
+
+                if nulled = Some elementPosition then
+                    "null"
+                else
+                    renderFramework namePosition versionPosition f
+            )
+            |> String.concat ","
+            |> sprintf """"%s":[%s]""" name
+
+        let options =
+            if nulled = Some Position.AtRuntimeOptions then
+                "null"
+            else
+                [
+                    $""""tfm":%s{value Position.AtTfm model.Tfm}"""
+
+                    match model.Framework with
+                    | Some f ->
+                        $""""framework":%s{renderFramework Position.AtFrameworkName Position.AtFrameworkVersion f}"""
+                    | None -> ()
+
+                    renderList
+                        "frameworks"
+                        (fun i ->
+                            Position.AtFrameworksName i, Position.AtFrameworksVersion i, Position.AtFrameworksElement i
+                        )
+                        model.Frameworks
+
+                    renderList
+                        "includedFrameworks"
+                        (fun i -> Position.AtIncludedName i, Position.AtIncludedVersion i, Position.AtIncludedElement i)
+                        model.IncludedFrameworks
+                ]
+                |> String.concat ","
+                |> sprintf "{%s}"
+
+        $"""{{"runtimeOptions":%s{options}}}"""
+
+    let private genFrameworkModel : Gen<FrameworkModel> =
+        Gen.zip genSafeString genSafeString
+        |> Gen.map (fun (name, version) ->
+            {
+                Name = name
+                Version = version
+            }
+        )
+
+    let private genConfigModel : Gen<ConfigModel> =
+        gen {
+            let! tfm = genSafeString
+            let! framework = Gen.optionOf genFrameworkModel
+            let! frameworks = Gen.listOf genFrameworkModel
+            let! included = Gen.listOf genFrameworkModel
+
+            return
+                {
+                    Tfm = tfm
+                    Framework = framework
+                    Frameworks = frameworks
+                    IncludedFrameworks = included
+                }
+        }
+
+    [<Test>]
+    let ``A null anywhere a non-nullable member sits is rejected`` () =
+        let property (model : ConfigModel) : bool =
+            // Control: the same document without any null parses, and parses back to the model it was
+            // rendered from. Without this, a document which was malformed for some other reason would
+            // make every rejection below vacuous.
+            let control = DotnetRuntime.DeserializeRuntimeConfig (renderConfig model None)
+
+            let asModel (f : RuntimeConfigFramework) : FrameworkModel =
+                {
+                    Name = f.Name
+                    Version = f.Version
+                }
+
+            control.RuntimeOptions.Tfm |> shouldEqual model.Tfm
+
+            control.RuntimeOptions.Framework
+            |> Option.ofObj
+            |> Option.map asModel
+            |> shouldEqual model.Framework
+
+            control.RuntimeOptions.Frameworks
+            |> Seq.map asModel
+            |> List.ofSeq
+            |> shouldEqual model.Frameworks
+
+            control.RuntimeOptions.IncludedFrameworks
+            |> Seq.map asModel
+            |> List.ofSeq
+            |> shouldEqual model.IncludedFrameworks
+
+            for position in positions model do
+                let content = renderConfig model (Some position)
+
+                let exn =
+                    Assert.Throws<JsonException> (fun () -> DotnetRuntime.DeserializeRuntimeConfig content |> ignore)
+
+                exn.Message |> shouldContainText (memberName position)
+
+            true
+
+        Check.One (Config.QuickThrowOnFailure.WithMaxTest 200, Prop.forAll (Arb.fromGen genConfigModel) property)


### PR DESCRIPTION
A runtimeconfig.json of the form `{"runtimeOptions":null}` gave consumers a `NullReferenceException` from their own code rather than an error naming the file.

C#'s `required` constrains the JSON member to be *present*; it says nothing about its value. So `{"runtimeOptions":null}` satisfies `required` and lands a null in a slot the type declares can never hold one. This is in 0.5.1, already on NuGet.

The same hole was in `RuntimeOptions.Tfm`, `RuntimeConfigFramework.Name` and `.Version`. All four are fixed.

## Reject, rather than represent

Measured against a real host on Microsoft.NETCore.App 9.0.0,

| file | host result |
|---|---|
| `"tfm": null`, `"name": null`, `"version": null` | exit `0x8000808b` (ResolverInitFailure), no output at all |
| `"runtimeOptions": null` | treated as `{}` — "did not specify a framework" (`0x83`) |
| `"runtimeOptions"` absent | "Invalid runtimeconfig.json" (`0x93`) |
| `"configProperties": null` | runs, exit 0 |

For three of the four there is no value for a caller to deal with: such a file does not produce a runnable app under any reading, so handing back a null only moves the failure somewhere less informative.

`runtimeOptions` is the one place this is our policy rather than the format's, since the host does distinguish "null" from "absent". It is refused anyway, because an empty options object is not representable here either — `Tfm` is itself non-nullable — so the alternative is not "report what the file says" but "hand back a null and hope". Both spellings of "this file says nothing" are now treated alike, and that divergence is recorded on the property.

The check lives in the `init` accessors rather than in a converter or in `DeserializeRuntimeConfig`, because the invariant belongs to the type: these records are public, so a consumer can deserialize them directly (the test suite does) or build one in code, and both paths must uphold it. An accessor also covers an element nested in `frameworks`/`includedFrameworks` with no extra machinery.

## Two things found while doing it

**A null list *element*.** `"frameworks":[null]` constructs no `RuntimeConfigFramework` at all, so no accessor runs, and the null lands in a list whose element type is non-nullable; `SelectRuntime` then throws on `x.Name`. Caught in review, confirmed, and fixed on the list accessor, with a `AtFrameworksElement`/`AtIncludedElement` position added to the property test — which is what should have caught it in the first place.

**Lists were retained as mutable aliases.** What the deserializer builds is a `List<T>`, which anyone holding the `IReadOnlyList<T>` can downcast and write to, and a caller who passes a list in can null an entry afterwards. Either falsifies the invariant this change asserts, so the accessors now store a `ReadOnlyCollection<T>` over a fresh array.

That last one has a consequence worth knowing at review time: two records built in code from the same source list now hold different list instances, and this record's compiler-generated equality compares lists by reference, so they compare unequal. That was already true of two separately-parsed configs; it is now also true of two built from one list.

## Known, not fixed here

`Tfm` is `required`, but a real host runs an app whose runtimeconfig.json omits `tfm` entirely (measured, exit 0) — so this library rejects a file the host accepts. That is the converse defect, and fixing it means deciding whether `Tfm` becomes nullable, which is its own API decision rather than part of a null-safety fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
